### PR TITLE
Do not try to guess exact folding boundaries

### DIFF
--- a/src/main/java/com/redhat/devtools/lsp4ij/features/foldingRange/LSPFoldingRangeBuilder.java
+++ b/src/main/java/com/redhat/devtools/lsp4ij/features/foldingRange/LSPFoldingRangeBuilder.java
@@ -66,8 +66,10 @@ public class LSPFoldingRangeBuilder extends CustomFoldingBuilder {
         List<FoldingRange> foldingRanges = getFoldingRanges(file);
         if (!ContainerUtil.isEmpty(foldingRanges)) {
             for (FoldingRange foldingRange : foldingRanges) {
-                TextRange textRange = getTextRange(foldingRange, file, document);
-                if ((textRange != null) && (textRange.getLength() > 0)) {
+                int start = getStartOffset(foldingRange, document);
+                int end = getEndOffset(foldingRange, document);
+                TextRange textRange = TextRange.create(start, end);
+                if (textRange.getLength() > 0) {
                     descriptors.add(new FoldingDescriptor(
                             root.getNode(),
                             textRange,


### PR DESCRIPTION
Some folding ranges from LSP server, especially imports, can start with brace, but not end with one. Guessing of boundaries based on braces changes folds significantly and incorrectly